### PR TITLE
Bugfix missing routes const, request auth header

### DIFF
--- a/Functions/util/request.js
+++ b/Functions/util/request.js
@@ -58,7 +58,7 @@ function makeRequest({
     // and the auth token if needed
     if (needsAuth && authToken !== '') {
         // Include both the headers and the query just in case one or the other fails
-        headers['authorization'] = `Bearer: ${authToken}`
+        headers['authorization'] = `Bearer ${authToken}`
         fullURL += `&token=${authToken}`
     } else if (needsAuth && authToken === '') {
         throw throwError(`You used a authenicated function without a token. Please set a token in the 'esi.json' file in ${path.join(__dirname, '../../../')}.`, `NO_AUTH_TOKEN`)

--- a/Functions/utility.js
+++ b/Functions/utility.js
@@ -5,7 +5,8 @@ let log = require('./util/log')
 const {
     projectConfig,
     localConfig,
-    server
+    server,
+    routes
 } = require('./util/constants')
 
 module.exports = {


### PR DESCRIPTION
I tried to use esi.character.standings() which requires authorization.  When I initialized the esi object with a token, utility.js complained of an undefined variable.  I found it in constants.js and followed the existing pattern to add it to utility.js.

After that, I encountered an auth error when trying to pull my character's standings.  I found in request.js that the authorization header string had a colon in it, which isn't what ESI expects, so I removed it, tested, and found it fixed.  I can successfully call an endpoint that requires authorization now.